### PR TITLE
pygments: get rid of that annoying install message

### DIFF
--- a/packages/pygments.rb
+++ b/packages/pygments.rb
@@ -22,6 +22,6 @@ class Pygments < Package
   })
 
   def self.install
-    system "pip3 install pygments --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
+    system "pip3 install pygments --no-warn-script-location --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR}"
   end
 end


### PR DESCRIPTION
Fixes Install Warning:
```
Collecting pygments
  Downloading Pygments-2.7.3-py3-none-any.whl (950 kB)
Installing collected packages: pygments
  WARNING: The script pygmentize is installed in '/usr/local/tmp/crew/dest/usr/local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
Successfully installed pygments-2.7.3
```
A version bump isn't needed here.

Works properly:
- [x] x86_64
